### PR TITLE
Fix logic in include to properly break when a relative file is found

### DIFF
--- a/src/app/code/local/Aligent/GeoIP/Helper/Data.php
+++ b/src/app/code/local/Aligent/GeoIP/Helper/Data.php
@@ -197,11 +197,16 @@ class Aligent_GeoIP_Helper_Data extends Mage_Core_Helper_Abstract {
                 $datFilePath = $dir . DS . $filename;
                 if (strpos($datFilePath, '/') !== 0) {
                     // First look for file on the include path
-                    if ((function_exists('stream_resolve_include_path') && $_filename = stream_resolve_include_path($datFilePath)) === false) {
-                        // Then look for the file relative to the Magento root.
-                        if (!file_exists($_filename = Mage::getBaseDir() . DS . $datFilePath)) {
-                            throw new Exception (sprintf('Unable to find file: "%s"', $datFilePath));
+                    if (function_exists('stream_resolve_include_path')) {
+                        $_filename = stream_resolve_include_path($datFilePath);
+                        if ($_filename !== false) {
+                            break;
                         }
+                    }
+                    // Then look for the file relative to the Magento root.
+                    $_filename = Mage::getBaseDir() . DS . $datFilePath;
+                    if (file_exists($_filename)) {
+                        break;
                     }
                 } elseif (file_exists($datFilePath)) {
                     $_filename = $datFilePath;

--- a/src/app/code/local/Aligent/GeoIP/Helper/Data.php
+++ b/src/app/code/local/Aligent/GeoIP/Helper/Data.php
@@ -213,6 +213,11 @@ class Aligent_GeoIP_Helper_Data extends Mage_Core_Helper_Abstract {
                     break;
                 }
             }
+
+            if (!file_exists($_filename)) {
+                throw new Exception (sprintf('Unable to find file: "%s"', $_filename));
+            }
+
             return geoip_open($_filename, $flags);
         } catch (Exception $e) {
             $message = $e->getMessage();


### PR DESCRIPTION
If a relative file was found, it would not break and continue the loop, meaning it wasn't possible to prefer a relative filename over an absolute one